### PR TITLE
Add "quiet mode": new config variable $doNotWriteToStdout

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -235,6 +235,10 @@ function logFinishBackupProcess()
     {
         $script:fullNotificationMessage += "$msg`n`n"
         doRemoteNotifications $fullNotificationMessage
+        if ($doNotWriteToStdout -and !$globalSuccessStatus)
+        {
+            Write-Error "$fullNotificationMessage"
+        }
     }
 }
 
@@ -281,7 +285,14 @@ function doDuplicacyCommand($arg)
 
 function doCall($command, $arg)
 {
-    & $command @arg *>&1 | Tee-Object -FilePath "$( $log.filePath )" -Append
+    if ($doNotWriteToStdout)
+    {
+        & $command @arg *>&1 | Out-File "$( $log.filePath )" -Append
+    }
+    else
+    {
+        & $command @arg *>&1 | Tee-Object -FilePath "$( $log.filePath )" -Append
+    }
 }
 
 

--- a/config.default.ps1
+++ b/config.default.ps1
@@ -146,3 +146,8 @@ $duplicacyPruneExtraOptionsOffsite = " -all -storage $offsiteStorageName "
 # If $mergeNotificationsIntoOne is set to $true then all notifications will be merged into a single one.
 # Basically you get a single notification at the end with the complete text instead of multiple notifications.
 $mergeNotificationsIntoOne = $false
+
+# By default, log messages will be written to standard output and also to a log file.
+# If you want the backup script to operate in "quiet mode", for example when it is being called by cron,
+# set $doNotWriteToStdout to $true.
+$doNotWriteToStdout = $false


### PR DESCRIPTION
Helpful when running `backup.ps1` through cron, and you don't want cron to email you the output every time.

Note: if `$globalSuccessStatus` indicates that there has been a failure, something will be written to stderr at the end of the job.